### PR TITLE
Associate ads with instruments.

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -79,4 +79,5 @@ rails g model instrument name:string:uniq description:text
 rails g model advertiser name:string:uniq description:text url:string
 rails g model ad advertiser:references title:string content:text url:string image_url:string
 rails g model ad_placement ad:references start_date:date end_date:date price:integer
+rails g model ad_instrument ad:references instrument:references
 ````

--- a/app/controllers/api/v1/ad_instruments_controller.rb
+++ b/app/controllers/api/v1/ad_instruments_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::AdInstrumentsController < Api::V1::ApiController
+  before_action :set_resource, only: [:destroy]
+
+  # POST /api/v1/ad_instruments
+  def create
+    ad_instrument = AdInstrument.new(resource_params)
+    save_and_render_json(ad_instrument)
+  end
+
+  # DELETE /api/v1/ad_instruments/:id
+  def destroy
+    destroy_and_render_json(@ad_instrument)
+  end
+
+private
+
+  def set_resource
+    @ad_instrument = AdInstrument.find(params[:id])
+  end
+
+  def resource_params
+    params.require(:ad_instrument).permit(:ad_id, :instrument_id)
+  end
+end

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -5,6 +5,8 @@ class Ad < ApplicationRecord
 
   belongs_to :advertiser
   has_many :ad_placements
+  has_many :ad_instruments
+  has_many :instruments, through: :ad_instruments
 
   alias :placements :ad_placements
 end

--- a/app/models/ad_instrument.rb
+++ b/app/models/ad_instrument.rb
@@ -1,0 +1,9 @@
+class AdInstrument < ApplicationRecord
+  belongs_to :ad
+  belongs_to :instrument
+
+  validates_associated :ad
+  validates_associated :instrument
+  validates :ad, {presence:true}
+  validates :instrument, {presence:true}
+end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,3 +1,6 @@
 class Instrument < ApplicationRecord
   validates :name, {presence: true, uniqueness: true}
+
+  has_many :ad_instruments
+  has_many :ads, through: :ad_instruments
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :advertisers, only: [:index, :show, :create, :update, :destroy]
       resources :ads, only: [:index, :show, :create, :update, :destroy]
       resources :ad_placements, only: [:index, :show, :create, :update, :destroy]
+      resources :ad_instruments, only: [:create, :destroy]
     end
   end
 end

--- a/db/migrate/20170602043634_create_ad_instruments.rb
+++ b/db/migrate/20170602043634_create_ad_instruments.rb
@@ -1,0 +1,10 @@
+class CreateAdInstruments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :ad_instruments do |t|
+      t.references :ad, foreign_key: true
+      t.references :instrument, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170601222609) do
+ActiveRecord::Schema.define(version: 20170602043634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ad_instruments", force: :cascade do |t|
+    t.integer  "ad_id"
+    t.integer  "instrument_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["ad_id"], name: "index_ad_instruments_on_ad_id", using: :btree
+    t.index ["instrument_id"], name: "index_ad_instruments_on_instrument_id", using: :btree
+  end
 
   create_table "ad_placements", force: :cascade do |t|
     t.integer  "ad_id"
@@ -53,6 +62,8 @@ ActiveRecord::Schema.define(version: 20170601222609) do
     t.index ["name"], name: "index_instruments_on_name", unique: true, using: :btree
   end
 
+  add_foreign_key "ad_instruments", "ads"
+  add_foreign_key "ad_instruments", "instruments"
   add_foreign_key "ad_placements", "ads"
   add_foreign_key "ads", "advertisers"
 end

--- a/spec/controllers/api/v1/ad_instruments_controller_spec.rb
+++ b/spec/controllers/api/v1/ad_instruments_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require_relative '../../../support/api/v1/create'
+require_relative '../../../support/api/v1/destroy'
+
+RSpec.describe Api::V1::AdInstrumentsController, type: :controller do
+  describe "POST #create" do
+    it_behaves_like "a create endpoint", AdInstrument  do
+      let(:ad){ create(:ad)}
+      let(:instrument){ create(:instrument) }
+      let(:resource_params){
+        {
+          ad_id: ad.id,
+          instrument_id: instrument.id,
+        }
+      }
+    end
+
+    it_behaves_like "a create endpoint which validates presence", AdInstrument, [:ad, :instrument] do
+      let(:resource_params){ {ad_id: "", instrument_id: ""} }
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it_behaves_like "a destroy endpoint", AdInstrument
+  end
+end

--- a/spec/factories/ad_instruments.rb
+++ b/spec/factories/ad_instruments.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :ad_instrument do
+    ad
+    instrument
+  end
+end

--- a/spec/models/ad_instrument_spec.rb
+++ b/spec/models/ad_instrument_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AdInstrument, type: :model do
+  describe "associations" do
+    it { should belong_to(:ad) }
+    it { should belong_to(:instrument) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:ad) }
+    it { should validate_presence_of(:instrument) }
+  end
+end

--- a/spec/models/ad_spec.rb
+++ b/spec/models/ad_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Ad, type: :model do
   describe "associations" do
     it { should belong_to(:advertiser) }
     it { should have_many(:ad_placements) }
+    it { should have_many(:ad_instruments) }
+    it { should have_many(:instruments).through(:ad_instruments) }
   end
 
   describe "validations" do

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Instrument, type: :model do
+  describe "associations" do
+    it { should have_many(:ad_instruments) }
+    it { should have_many(:ads).through(:ad_instruments) }
+  end
+
   describe "validations" do
     it { should validate_presence_of(:name) }
 


### PR DESCRIPTION
In the original design, we said an ad could have one and only one associated instrument. But the client would like to be able to assign an ad to all instruments, or none. So this many-to-many relationship is more appropriate.